### PR TITLE
Mitigate CVE-2024-56406: A heap buffer overflow vulnerability was dis…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+perl (5.36.0-10deepin1) unstable; urgency=medium
+
+  * Mitigate CVE-2024-56406: A heap buffer overflow vulnerability was
+    discovered in Perl.
+    https://github.com/deepin-community/sig-deepin-security/issues/69
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Mon, 14 Apr 2025 17:23:53 +0800
+
 perl (5.36.0-10) unstable; urgency=medium
 
   * [SECURITY] CVE-2023-47039: Write past buffer end via illegal

--- a/debian/patches/fixes/CVE-2024-56406.diff
+++ b/debian/patches/fixes/CVE-2024-56406.diff
@@ -1,0 +1,27 @@
+From 87f42aa0e0096e9a346c9672aa3a0bd3bef8c1dd Mon Sep 17 00:00:00 2001
+From: Karl Williamson <khw@cpan.org>
+Date: Wed, 18 Dec 2024 18:25:29 -0700
+Subject: [PATCH] CVE-2024-56406: Heap-buffer-overflow with tr//
+
+This was due to underallocating needed space.  If the translation forces
+something to become UTF-8 that is initially bytes, that UTF-8 could
+now require two bytes where previously a single one would do.
+
+(cherry picked from commit f93109c8a6950aafbd7488d98e112552033a3686)
+---
+ op.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/op.c b/op.c
+index 69ff030e88eb..298b2926338a 100644
+--- a/op.c
++++ b/op.c
+@@ -6881,6 +6881,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
+                  * same time.  But otherwise one crosses before the other */
+                 if (t_cp < 256 && r_cp_end > 255 && r_cp != t_cp) {
+                     can_force_utf8 = TRUE;
++                    max_expansion = MAX(2, max_expansion);
+                 }
+             }
+ 
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -51,3 +51,4 @@ fixes/readline-stream-errors.diff
 fixes/readline-stream-errors-test.diff
 fixes/lto-test-fix.diff
 fixes/CVE-2023-47038.diff
+fixes/CVE-2024-56406.diff


### PR DESCRIPTION
…covered in Perl

https://github.com/deepin-community/sig-deepin-security/issues/69