### PR TITLE
Fix CVE-2023-31484, CVE-2023-31486, CVE-2026-9538, CVE-2026-48959, CVE-2026-48962, CVE-2026-8376, CVE-2026-42496 and CVE-2026-42497

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+perl (5.36.0-10deepin3) unstable; urgency=medium
+
+  * d/p/0061-Add-verify_SSL-1-to-HTTP-Tiny-to-verify-https-server.patch
+    Fixes CVE-2023-31484
+  * d/p/0062-Change-verify_SSL-default-to-1-add-ENV-var-to-enable.patch
+    Fixes CVE-2023-31486
+  * d/p/0063-Cpan-entry-size-during-read.patch
+    Fixes CVE-2026-9538
+  * d/p/0064-Fix-typo-in-fastForward-72.patch
+    Fixes CVE-2026-48959
+  * d/p/0065-remove-use-of-eval-in-globmapper.-73.patch
+    Fixes CVE-2026-48962
+  * d/p/0066-perl-perl-security-147-test-cases.patch
+  * d/p/0067-perl-perl-security-147-test-against-the-actual-chara.patch
+    Fixes CVE-2026-8376
+  * d/p/0068-Validate-symlink-and-hardlink-linkname-in-SECURE-MOD.patch
+    Fixes CVE-2026-42496, CVE-2026-42497
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Thu, 28 May 2026 16:28:45 +0800
+
 perl (5.36.0-10deepin2) unstable; urgency=medium
 
   * Mitigate CVE-2025-40909: Clone dirhandles without fchdir.

--- a/debian/patches/0061-Add-verify_SSL-1-to-HTTP-Tiny-to-verify-https-server.patch
+++ b/debian/patches/0061-Add-verify_SSL-1-to-HTTP-Tiny-to-verify-https-server.patch
@@ -1,0 +1,20 @@
+From: Stig Palmquist <git@stig.io>
+Date: Tue, 28 Feb 2023 11:54:06 +0100
+Subject: Add verify_SSL=>1 to HTTP::Tiny to verify https server identity
+
+---
+ cpan/CPAN/lib/CPAN/HTTP/Client.pm | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cpan/CPAN/lib/CPAN/HTTP/Client.pm b/cpan/CPAN/lib/CPAN/HTTP/Client.pm
+index 4fc792c..a616fee 100644
+--- a/cpan/CPAN/lib/CPAN/HTTP/Client.pm
++++ b/cpan/CPAN/lib/CPAN/HTTP/Client.pm
+@@ -32,6 +32,7 @@ sub mirror {
+ 
+     my $want_proxy = $self->_want_proxy($uri);
+     my $http = HTTP::Tiny->new(
++        verify_SSL => 1,
+         $want_proxy ? (proxy => $self->{proxy}) : ()
+     );
+ 

--- a/debian/patches/0062-Change-verify_SSL-default-to-1-add-ENV-var-to-enable.patch
+++ b/debian/patches/0062-Change-verify_SSL-default-to-1-add-ENV-var-to-enable.patch
@@ -1,0 +1,333 @@
+From: Stig Palmquist <git@stig.io>
+Date: Mon, 5 Jun 2023 16:46:22 +0200
+Subject: Change verify_SSL default to 1,
+ add ENV var to enable insecure default
+
+- Changes the `verify_SSL` default parameter from `0` to `1`
+
+  Based on patch by Dominic Hargreaves:
+  https://salsa.debian.org/perl-team/interpreter/perl/-/commit/1490431e40e22052f75a0b3449f1f53cbd27ba92
+
+  Fixes CVE-2023-31486
+
+- Add check for `$ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT}` that
+  enables the previous insecure default behaviour if set to `1`.
+
+  This provides a workaround for users who encounter problems with the
+  new `verify_SSL` default.
+
+  Example to disable certificate checks:
+  ```
+    $ PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1 ./script.pl
+  ```
+
+- Updates to documentation:
+  - Describe changing the verify_SSL value
+  - Describe the escape-hatch environment variable
+  - Remove rationale for not enabling verify_SSL
+  - Add missing certificate search paths
+  - Replace "SSL" with "TLS/SSL" where appropriate
+  - Use "machine-in-the-middle" instead of "man-in-the-middle"
+
+- Added `180_verify_SSL.t`
+  - Test that `verify_SSL` default is `1`
+  - Test that `PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT` behaves as expected
+  - Test that using different values for `verify_SSL` and legacy `verify_ssl`
+    doesn't disable cert checks
+---
+ cpan/HTTP-Tiny/lib/HTTP/Tiny.pm   |  90 ++++++++++++++++---------------
+ cpan/HTTP-Tiny/t/180_verify_SSL.t | 109 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 155 insertions(+), 44 deletions(-)
+ create mode 100644 cpan/HTTP-Tiny/t/180_verify_SSL.t
+
+diff --git a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+index 83ca06d..c2f9180 100644
+--- a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
++++ b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+@@ -40,10 +40,14 @@ sub _croak { require Carp; Carp::croak(@_) }
+ #pod * C<timeout> — Request timeout in seconds (default is 60) If a socket open,
+ #pod   read or write takes longer than the timeout, the request response status code
+ #pod   will be 599.
+-#pod * C<verify_SSL> — A boolean that indicates whether to validate the SSL
+-#pod   certificate of an C<https> — connection (default is false)
++#pod * C<verify_SSL> — A boolean that indicates whether to validate the TLS/SSL
++#pod   certificate of an C<https> — connection (default is true)
+ #pod * C<SSL_options> — A hashref of C<SSL_*> — options to pass through to
+ #pod   L<IO::Socket::SSL>
++#pod * C<$ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT}> - Changes the default
++#pod   certificate verification behavior to not check server identity if set to 1.
++#pod   Only effective if C<verify_SSL> is not set. Added in version 0.083.
++#pod
+ #pod
+ #pod An accessor/mutator method exists for each attribute.
+ #pod
+@@ -111,11 +115,17 @@ sub timeout {
+ sub new {
+     my($class, %args) = @_;
+ 
++    # Support lower case verify_ssl argument, but only if verify_SSL is not
++    # true.
++    if ( exists $args{verify_ssl} ) {
++        $args{verify_SSL}  ||= $args{verify_ssl};
++    }
++
+     my $self = {
+         max_redirect => 5,
+         timeout      => defined $args{timeout} ? $args{timeout} : 60,
+         keep_alive   => 1,
+-        verify_SSL   => $args{verify_SSL} || $args{verify_ssl} || 0, # no verification by default
++        verify_SSL   => defined $args{verify_SSL} ? $args{verify_SSL} : _verify_SSL_default(),
+         no_proxy     => $ENV{no_proxy},
+     };
+ 
+@@ -134,6 +144,13 @@ sub new {
+     return $self;
+ }
+ 
++sub _verify_SSL_default {
++    my ($self) = @_;
++    # Check if insecure default certificate verification behaviour has been
++    # changed by the user by setting PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1
++    return (($ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} || '') eq '1') ? 0 : 1;
++}
++
+ sub _set_proxies {
+     my ($self) = @_;
+ 
+@@ -1055,7 +1072,7 @@ sub new {
+         timeout          => 60,
+         max_line_size    => 16384,
+         max_header_lines => 64,
+-        verify_SSL       => 0,
++        verify_SSL       => HTTP::Tiny::_verify_SSL_default(),
+         SSL_options      => {},
+         %args
+     }, $class;
+@@ -2043,11 +2060,11 @@ proxy
+ timeout
+ verify_SSL
+ 
+-=head1 SSL SUPPORT
++=head1 TLS/SSL SUPPORT
+ 
+ Direct C<https> connections are supported only if L<IO::Socket::SSL> 1.56 or
+ greater and L<Net::SSLeay> 1.49 or greater are installed. An error will occur
+-if new enough versions of these modules are not installed or if the SSL
++if new enough versions of these modules are not installed or if the TLS
+ encryption fails. You can also use C<HTTP::Tiny::can_ssl()> utility function
+ that returns boolean to see if the required modules are installed.
+ 
+@@ -2055,7 +2072,7 @@ An C<https> connection may be made via an C<http> proxy that supports the CONNEC
+ command (i.e. RFC 2817).  You may not proxy C<https> via a proxy that itself
+ requires C<https> to communicate.
+ 
+-SSL provides two distinct capabilities:
++TLS/SSL provides two distinct capabilities:
+ 
+ =over 4
+ 
+@@ -2069,24 +2086,17 @@ Verification of server identity
+ 
+ =back
+ 
+-B<By default, HTTP::Tiny does not verify server identity>.
+-
+-Server identity verification is controversial and potentially tricky because it
+-depends on a (usually paid) third-party Certificate Authority (CA) trust model
+-to validate a certificate as legitimate.  This discriminates against servers
+-with self-signed certificates or certificates signed by free, community-driven
+-CA's such as L<CAcert.org|http://cacert.org>.
++B<By default, HTTP::Tiny verifies server identity>.
+ 
+-By default, HTTP::Tiny does not make any assumptions about your trust model,
+-threat level or risk tolerance.  It just aims to give you an encrypted channel
+-when you need one.
++This was changed in version 0.083 due to security concerns. The previous default
++behavior can be enabled by setting C<$ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT}>
++to 1.
+ 
+-Setting the C<verify_SSL> attribute to a true value will make HTTP::Tiny verify
+-that an SSL connection has a valid SSL certificate corresponding to the host
+-name of the connection and that the SSL certificate has been verified by a CA.
+-Assuming you trust the CA, this will protect against a L<man-in-the-middle
+-attack|http://en.wikipedia.org/wiki/Man-in-the-middle_attack>.  If you are
+-concerned about security, you should enable this option.
++Verification is done by checking that that the TLS/SSL connection has a valid
++certificate corresponding to the host name of the connection and that the
++certificate has been verified by a CA. Assuming you trust the CA, this will
++protect against L<machine-in-the-middle
++attacks|http://en.wikipedia.org/wiki/Machine-in-the-middle_attack>.
+ 
+ Certificate verification requires a file containing trusted CA certificates.
+ 
+@@ -2094,34 +2104,26 @@ If the environment variable C<SSL_CERT_FILE> is present, HTTP::Tiny
+ will try to find a CA certificate file in that location.
+ 
+ If the L<Mozilla::CA> module is installed, HTTP::Tiny will use the CA file
+-included with it as a source of trusted CA's.  (This means you trust Mozilla,
+-the author of Mozilla::CA, the CPAN mirror where you got Mozilla::CA, the
+-toolchain used to install it, and your operating system security, right?)
++included with it as a source of trusted CA's.
+ 
+ If that module is not available, then HTTP::Tiny will search several
+ system-specific default locations for a CA certificate file:
+ 
+-=over 4
+-
+-=item *
+-
+-/etc/ssl/certs/ca-certificates.crt
+-
+-=item *
+-
+-/etc/pki/tls/certs/ca-bundle.crt
+-
+-=item *
+-
+-/etc/ssl/ca-bundle.pem
+-
+-=back
++=for :list
++* /etc/ssl/certs/ca-certificates.crt
++* /etc/pki/tls/certs/ca-bundle.crt
++* /etc/ssl/ca-bundle.pem
++* /etc/openssl/certs/ca-certificates.crt
++* /etc/ssl/cert.pem
++* /usr/local/share/certs/ca-root-nss.crt
++* /etc/pki/tls/cacert.pem
++* /etc/certs/ca-certificates.crt
+ 
+ An error will be occur if C<verify_SSL> is true and no CA certificate file
+ is available.
+ 
+-If you desire complete control over SSL connections, the C<SSL_options> attribute
+-lets you provide a hash reference that will be passed through to
++If you desire complete control over TLS/SSL connections, the C<SSL_options>
++attribute lets you provide a hash reference that will be passed through to
+ C<IO::Socket::SSL::start_SSL()>, overriding any options set by HTTP::Tiny. For
+ example, to provide your own trusted CA file:
+ 
+@@ -2131,7 +2133,7 @@ example, to provide your own trusted CA file:
+ 
+ The C<SSL_options> attribute could also be used for such things as providing a
+ client certificate for authentication to a server or controlling the choice of
+-cipher used for the SSL connection. See L<IO::Socket::SSL> documentation for
++cipher used for the TLS/SSL connection. See L<IO::Socket::SSL> documentation for
+ details.
+ 
+ =head1 PROXY SUPPORT
+diff --git a/cpan/HTTP-Tiny/t/180_verify_SSL.t b/cpan/HTTP-Tiny/t/180_verify_SSL.t
+new file mode 100644
+index 0000000..d6bc412
+--- /dev/null
++++ b/cpan/HTTP-Tiny/t/180_verify_SSL.t
+@@ -0,0 +1,109 @@
++#!perl
++
++use strict;
++use warnings;
++use Test::More 0.88;
++use lib 't';
++
++use HTTP::Tiny;
++
++delete $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT};
++
++{
++    my $ht = HTTP::Tiny->new();
++    is($ht->verify_SSL, 1, "verify_SSL is 1 by default");
++}
++
++{
++    my $ht = HTTP::Tiny->new(
++        verify_SSL => 0
++    );
++    is($ht->verify_SSL, 0, "verify_SSL=>0 sets 0");
++}
++
++{
++    my $ht = HTTP::Tiny->new(
++        verify_ssl => 0
++    );
++    is($ht->verify_SSL, 0, "verify_ssl=>0 sets 0");
++}
++
++{
++    my $ht = HTTP::Tiny->new(
++        verify_SSL => 1,
++        verify_ssl => 0
++    );
++    is($ht->verify_SSL, 1, "verify_SSL=>1 and verify_ssl=>0 sets 1");
++}
++
++{
++    my $ht = HTTP::Tiny->new(
++        verify_SSL => 0,
++        verify_ssl => 1
++    );
++    is($ht->verify_SSL, 1, "verify_SSL=>0 and verify_ssl=>1 sets 1");
++}
++
++{
++    my $ht = HTTP::Tiny->new(
++        verify_SSL => 0,
++        verify_ssl => 0
++    );
++    is($ht->verify_SSL, 0, "verify_SSL=>0 and verify_ssl=>0 sets 0");
++}
++
++{
++    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
++    my $ht = HTTP::Tiny->new();
++    is($ht->verify_SSL, 0, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1 changes verify_SSL default to 0");
++}
++
++{
++    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "0";
++    my $ht = HTTP::Tiny->new();
++    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=0 keeps verify_SSL default at 1");
++}
++
++{
++    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "False";
++    my $ht = HTTP::Tiny->new();
++    is($ht->verify_SSL, 1, "Unsupported PERL_HTTP_TINY_INSECURE_BY_DEFAULT=False keeps verify_SSL default at 1");
++}
++
++{
++    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
++    my $ht = HTTP::Tiny->new(verify_SSL=>1);
++    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1 does not override verify_SSL attribute set to 1");
++}
++
++{
++    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
++    my $ht = HTTP::Tiny->new(
++        verify_SSL => 1,
++        verify_ssl => 1
++    );
++    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1, verify_SSL=>1 and verify_ssl=>1 sets 1");
++}
++
++{
++    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
++    my $ht = HTTP::Tiny->new(
++        verify_SSL => 1,
++        verify_ssl => 0
++    );
++    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1, verify_SSL=>1 and verify_ssl=>0 sets 1");
++}
++
++{
++    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
++    my $ht = HTTP::Tiny->new(
++        verify_SSL => 0,
++        verify_ssl => 0
++    );
++    is($ht->verify_SSL, 0, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1, verify_SSL=>0 and verify_ssl=>0 sets 0");
++}
++
++
++
++done_testing;
++

--- a/debian/patches/0063-Cpan-entry-size-during-read.patch
+++ b/debian/patches/0063-Cpan-entry-size-during-read.patch
@@ -1,0 +1,71 @@
+From: Stig Palmquist <stig@stig.io>
+Date: Mon, 25 May 2026 19:11:34 +0100
+Subject: Cpan entry size during read
+
+Cap entry size during read to defend against attacker-controlled
+size-field memory DoS
+
+The tar header's 12-byte size field is attacker-controlled. Archive::Tar's
+non-skip extract path at Tar.pm:501 allocates a Perl scalar of the declared
+size before returning the read-short error, allowing a few-KB compressed
+archive declaring a 100 GB inner entry to trigger immediate multi-GB
+allocation. The existing $EXTRACT_BLOCK_SIZE is an output-side syswrite
+chunk size, not an input cap.
+
+Add $MAX_FILE_SIZE (default 1 GiB) checked once per entry, gating both the
+chunked-skip and full-slurp branches. Set to 0 to disable the cap.
+
+Signed-off-by: Chris 'BinGOs' Williams <chris@bingosnet.co.uk>
+---
+ cpan/Archive-Tar/lib/Archive/Tar.pm | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/cpan/Archive-Tar/lib/Archive/Tar.pm b/cpan/Archive-Tar/lib/Archive/Tar.pm
+index 476e646..192cc5a 100644
+--- a/cpan/Archive-Tar/lib/Archive/Tar.pm
++++ b/cpan/Archive-Tar/lib/Archive/Tar.pm
+@@ -24,6 +24,7 @@ use strict;
+ use vars qw[$DEBUG $error $VERSION $WARN $FOLLOW_SYMLINK $CHOWN $CHMOD
+             $DO_NOT_USE_PREFIX $HAS_PERLIO $HAS_IO_STRING $SAME_PERMISSIONS
+             $INSECURE_EXTRACT_MODE $ZERO_PAD_NUMBERS @ISA @EXPORT $RESOLVE_SYMLINK
++            $MAX_FILE_SIZE
+          ];
+ 
+ @ISA                    = qw[Exporter];
+@@ -39,6 +40,7 @@ $DO_NOT_USE_PREFIX      = 0;
+ $INSECURE_EXTRACT_MODE  = 0;
+ $ZERO_PAD_NUMBERS       = 0;
+ $RESOLVE_SYMLINK        = $ENV{'PERL5_AT_RESOLVE_SYMLINK'} || 'speed';
++$MAX_FILE_SIZE          = 1024 * 1024 * 1024;
+ 
+ BEGIN {
+     use Config;
+@@ -442,6 +444,14 @@ sub _read_tar {
+ 
+             my $block = BLOCK_SIZE->( $entry->size );
+ 
++            if ( $MAX_FILE_SIZE && $entry->size > $MAX_FILE_SIZE ) {
++                $self->_error( qq[Entry '] . $entry->full_path .
++                    qq[' declared size ] . $entry->size .
++                    qq[ bytes exceeds \$Archive::Tar::MAX_FILE_SIZE ] .
++                    qq[($MAX_FILE_SIZE); refusing to allocate] );
++                next LOOP;
++            }
++
+             $data = $entry->get_content_by_ref;
+ 
+ 	    my $skip = 0;
+@@ -2163,6 +2173,13 @@ numbers. Added for compatibility with C<busybox> implementations.
+ 
+ 		It won't work for terminal, pipe or sockets or every non seekable source.
+ 
++=head2 $Archive::Tar::MAX_FILE_SIZE
++
++This variable holds an upper bound on the per-entry declared size that
++C<Archive::Tar> will accept when reading an archive. Entries whose header
++claims a larger size are refused with an error before any read allocation.
++Defaults to 1 GiB. Set to 0 to disable the cap.
++
+ =cut
+ 
+ =head1 FAQ

--- a/debian/patches/0064-Fix-typo-in-fastForward-72.patch
+++ b/debian/patches/0064-Fix-typo-in-fastForward-72.patch
@@ -1,0 +1,23 @@
+From: pmqs <pmqs@cpan.org>
+Date: Fri, 15 May 2026 23:18:39 +0100
+Subject: Fix typo in fastForward #72
+
+---
+ cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm b/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
+index cfe56d3..1c1b93c 100644
+--- a/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
++++ b/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
+@@ -157,8 +157,8 @@ sub fastForward
+ 
+     while ($offset > 0)
+     {
+-        $c = length $offset
+-            if length $offset < $c ;
++        $c = $offset
++            if $offset < $c ;
+ 
+         $offset -= $c;
+ 

--- a/debian/patches/0065-remove-use-of-eval-in-globmapper.-73.patch
+++ b/debian/patches/0065-remove-use-of-eval-in-globmapper.-73.patch
@@ -1,0 +1,160 @@
+From: pmqs <pmqs@cpan.org>
+Date: Sat, 16 May 2026 17:48:34 +0100
+Subject: remove use of eval in globmapper. #73
+
+---
+ cpan/IO-Compress/lib/File/GlobMapper.pm | 52 +++++++++++++++++++++++++++------
+ cpan/IO-Compress/t/globmapper.t         | 52 ++++++++++++++++++++++++++++++++-
+ 2 files changed, 94 insertions(+), 10 deletions(-)
+
+diff --git a/cpan/IO-Compress/lib/File/GlobMapper.pm b/cpan/IO-Compress/lib/File/GlobMapper.pm
+index f015b16..8936146 100644
+--- a/cpan/IO-Compress/lib/File/GlobMapper.pm
++++ b/cpan/IO-Compress/lib/File/GlobMapper.pm
+@@ -29,6 +29,11 @@ our ($VERSION, @EXPORT_OK);
+ $VERSION = '1.001';
+ @EXPORT_OK = qw( globmap );
+ 
++our $BEGIN_DELIM = "\xFF";
++our $END_DELIM   = "\xFE";
++our $BACKSLASH_ESC = "\xFD";
++our $HASH_ESC = "\xFC";
++our $STAR_ESC = "\xFB";
+ 
+ our ($noPreBS, $metachars, $matchMetaRE, %mapping, %wildCount);
+ $noPreBS = '(?<!\\\)' ; # no preceding backslash
+@@ -310,14 +315,23 @@ sub _parseOutputGlob
+     }
+ 
+     my $noPreBS = '(?<!\\\)' ; # no preceding backslash
+-    #warn "noPreBS = '$noPreBS'\n";
++    my $noPreESC = '(?<![${BEGIN_DELIM}])' ; # no preceding backslash
+ 
+-    #$string =~ s/${noPreBS}\$(\d)/\${$1}/g;
+-    $string =~ s/${noPreBS}#(\d)/\${$1}/g;
+-    $string =~ s#${noPreBS}\*#\${inFile}#g;
+-    $string = '"' . $string . '"';
++    # escape any use of the delimiter symbols
++    # $string =~ s/(${BEGIN_DELIM}|${END_DELIM}|${BACKSLASH_ESC})/$1$1/g;
++
++    # escape \# and \*
++    $string =~ s/\\#/${HASH_ESC}/g;
++    $string =~ s/\\\*/${STAR_ESC}/g;
++
++    # Transform "#3" to BEGIN_DELIM 3 END_DELIM
++    $string =~ s/${noPreESC}#(\d)/${BEGIN_DELIM}${1}${END_DELIM}/g;
++
++    $string =~ s#\*#${BEGIN_DELIM}${END_DELIM}#g;
++
++    # print "INPUT  '$self->{InputPattern}'\n";
++    # print "OUTPUT '$self->{OutputGlob}' => '$string'\n";
+ 
+-    #print "OUTPUT '$self->{OutputGlob}' => '$string'\n";
+     $self->{OutputPattern} = $string ;
+ 
+     return 1 ;
+@@ -335,11 +349,31 @@ sub _getFiles
+         next if $inFiles{$inFile} ++ ;
+ 
+         my $outFile = $inFile ;
++        my @matches ;
++
++        my $noPreESC = '(?<![${BEGIN_DELIM}])' ; # no preceding backslash
+ 
+-        if ( $inFile =~ m/$self->{InputPattern}/ )
++        if (@matches = ($inFile =~ m/$self->{InputPattern}/ ))
+         {
+-            no warnings 'uninitialized';
+-            eval "\$outFile = $self->{OutputPattern};" ;
++            $outFile = $self->{OutputPattern};
++            my $ix = 1;
++
++            # get the filename glob
++            $outFile =~ s/${noPreESC}${BEGIN_DELIM}${END_DELIM}/$inFile/g;
++
++            # now each of the #1, #2,...
++            for my $pattern (@matches)
++            {
++                $outFile =~ s/${noPreESC}${BEGIN_DELIM}${ix}${END_DELIM}/$pattern/g;
++
++                ++ $ix;
++            }
++
++            # unescape
++            $outFile =~ s/${BEGIN_DELIM}${BEGIN_DELIM}/${BEGIN_DELIM}/g;
++            $outFile =~ s/${END_DELIM}${END_DELIM}/${END_DELIM}/g;
++            $outFile =~ s/${HASH_ESC}/#/g;
++            $outFile =~ s/${STAR_ESC}/*/g;
+ 
+             if (defined $outInMapping{$outFile})
+             {
+diff --git a/cpan/IO-Compress/t/globmapper.t b/cpan/IO-Compress/t/globmapper.t
+index c97beb6..926b5e3 100644
+--- a/cpan/IO-Compress/t/globmapper.t
++++ b/cpan/IO-Compress/t/globmapper.t
+@@ -24,7 +24,7 @@ Perl $]" )
+     $extra = 1
+         if eval { require Test::NoWarnings ;  import Test::NoWarnings; 1 };
+ 
+-    plan tests => 68 + $extra ;
++    plan tests => 76 + $extra ;
+ 
+     use_ok('File::GlobMapper') ;
+ }
+@@ -290,6 +290,56 @@ Perl $]" )
+         ], "  got mapping";
+ }
+ 
++{
++    title "check escaping";
++
++    my $tmpDir ;#= 'td';
++    my $lex = LexDir->new( $tmpDir );
++
++    my $BEGIN_DELIM = "\xFF";
++    my $END_DELIM   = "\xFE";
++
++    #mkdir $tmpDir, 0777 ;
++
++    touch map { "$tmpDir/$_.tmp" } qw( abc1 abc2 abc3 ) ;
++
++    my $map = File::GlobMapper::globmap("$tmpDir/*b*.tmp", "$tmpDir/X-${BEGIN_DELIM}#2-#1${END_DELIM}-X");
++    ok $map, "  got map"
++        or diag $File::GlobMapper::Error ;
++
++    is @{ $map }, 3, "  returned 3 maps";
++    is_deeply $map,
++        [ [map { "$tmpDir/$_" } ("abc1.tmp", "X-${BEGIN_DELIM}c1-a${END_DELIM}-X")],
++          [map { "$tmpDir/$_" } ("abc2.tmp", "X-${BEGIN_DELIM}c2-a${END_DELIM}-X")],
++          [map { "$tmpDir/$_" } ("abc3.tmp", "X-${BEGIN_DELIM}c3-a${END_DELIM}-X")],
++        ], "  got mapping";
++}
++
++{
++    title "check backslash escaping";
++
++    my $tmpDir ;#= 'td';
++    my $lex = LexDir->new( $tmpDir );
++
++    my $BEGIN_DELIM = "\xFF";
++    my $END_DELIM   = "\xFE";
++
++    #mkdir $tmpDir, 0777 ;
++
++    touch map { "$tmpDir/$_.tmp" } qw( abc1 abc2 abc3 ) ;
++
++    my $map = File::GlobMapper::globmap("$tmpDir/*b*.tmp", $tmpDir . '/X-#2-\\#1\\*-X');
++    ok $map, "  got map"
++        or diag $File::GlobMapper::Error ;
++
++    is @{ $map }, 3, "  returned 3 maps";
++    is_deeply $map,
++        [ [map { "$tmpDir/$_" } ("abc1.tmp", "X-c1-#1*-X")],
++          [map { "$tmpDir/$_" } ("abc2.tmp", "X-c2-#1*-X")],
++          [map { "$tmpDir/$_" } ("abc3.tmp", "X-c3-#1*-X")],
++        ], "  got mapping";
++}
++
+ # TODO
+ # test each of the wildcard metacharacters can be mapped to the output filename
+ #

--- a/debian/patches/0066-perl-perl-security-147-test-cases.patch
+++ b/debian/patches/0066-perl-perl-security-147-test-cases.patch
@@ -1,0 +1,52 @@
+From: Tony Cook <tony@develop-help.com>
+Date: Tue, 12 May 2026 14:47:31 +1000
+Subject: perl/perl-security#147: test cases
+
+The suggested case from the ticket and an alternative.
+---
+ t/re/pat_psycho.t | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/t/re/pat_psycho.t b/t/re/pat_psycho.t
+index fe87ac1..7f7f624 100644
+--- a/t/re/pat_psycho.t
++++ b/t/re/pat_psycho.t
+@@ -10,7 +10,7 @@
+ use strict;
+ use warnings;
+ use 5.010;
+-
++use Config;
+ 
+ sub run_tests;
+ 
+@@ -33,7 +33,7 @@ BEGIN {
+ 
+ skip_all('$PERL_SKIP_PSYCHO_TEST set') if $ENV{PERL_SKIP_PSYCHO_TEST};
+ 
+-plan tests => 15;  # Update this when adding/deleting tests.
++plan tests => 17;  # Update this when adding/deleting tests.
+ 
+ run_tests() unless caller;
+ 
+@@ -213,6 +213,20 @@ EOF
+ 
+ 
+     }
++
++  SKIP:
++    { # sec #147
++        $Config{ptrsize} == 4
++          or skip "these only fail on x32 and use too much memory on x64", 2;
++        local $::TODO = "This crashes";
++        # original case
++        fresh_perl_like('/\x{10000}{1073741824}/',
++                        qr/Regexp out of space/, {}, "ssize_t overflow");
++
++        # synthesized but similar case
++        fresh_perl_like('/(?:\x{10001}\x{10000}){536870912}/',
++                        qr/Regexp out of space/, {}, "ssize_t overflow again");
++    }
+ } # End of sub run_tests
+ 
+ 1;

--- a/debian/patches/0067-perl-perl-security-147-test-against-the-actual-chara.patch
+++ b/debian/patches/0067-perl-perl-security-147-test-against-the-actual-chara.patch
@@ -1,0 +1,39 @@
+From: Tony Cook <tony@develop-help.com>
+Date: Tue, 12 May 2026 14:51:00 +1000
+Subject: perl/perl-security#147: test against the actual character lengths
+
+---
+ regcomp.c         | 7 +++++++
+ t/re/pat_psycho.t | 1 -
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/regcomp.c b/regcomp.c
+index 9c0338c..26f815a 100644
+--- a/regcomp.c
++++ b/regcomp.c
+@@ -5916,6 +5916,13 @@ S_study_chunk(pTHX_
+                                                (U8 *) SvEND(data->last_found))
+                                 - (U8*)s;
+                         l -= old;
++
++                        if (l > 0 &&
++                            (mincount >= SSize_t_MAX / (SSize_t)l
++                             || old > SSize_t_MAX - mincount * (SSize_t)l)) {
++                            FAIL("Regexp out of space");
++                        }
++
+                         /* Get the added string: */
+                         last_str = newSVpvn_utf8(s  + old, l, UTF);
+                         last_chrs = UTF ? utf8_length((U8*)(s + old),
+diff --git a/t/re/pat_psycho.t b/t/re/pat_psycho.t
+index 7f7f624..e5eecd6 100644
+--- a/t/re/pat_psycho.t
++++ b/t/re/pat_psycho.t
+@@ -218,7 +218,6 @@ EOF
+     { # sec #147
+         $Config{ptrsize} == 4
+           or skip "these only fail on x32 and use too much memory on x64", 2;
+-        local $::TODO = "This crashes";
+         # original case
+         fresh_perl_like('/\x{10000}{1073741824}/',
+                         qr/Regexp out of space/, {}, "ssize_t overflow");

--- a/debian/patches/0068-Validate-symlink-and-hardlink-linkname-in-SECURE-MOD.patch
+++ b/debian/patches/0068-Validate-symlink-and-hardlink-linkname-in-SECURE-MOD.patch
@@ -1,0 +1,78 @@
+From: Stig Palmquist <stig@stig.io>
+Date: Thu, 21 May 2026 19:59:21 +0100
+Subject: Validate symlink and hardlink linkname in SECURE MODE
+
+Signed-off-by: Chris 'BinGOs' Williams <chris@bingosnet.co.uk>
+---
+ cpan/Archive-Tar/lib/Archive/Tar.pm     | 30 ++++++++++++++++++++++++++++++
+ cpan/Archive-Tar/t/04_resolved_issues.t |  2 ++
+ 2 files changed, 32 insertions(+)
+
+diff --git a/cpan/Archive-Tar/lib/Archive/Tar.pm b/cpan/Archive-Tar/lib/Archive/Tar.pm
+index 192cc5a..f8869f1 100644
+--- a/cpan/Archive-Tar/lib/Archive/Tar.pm
++++ b/cpan/Archive-Tar/lib/Archive/Tar.pm
+@@ -954,6 +954,19 @@ sub _make_special_file {
+     my $err;
+ 
+     if( $entry->is_symlink ) {
++        if( !$INSECURE_EXTRACT_MODE ) {
++            my $linkname = $entry->linkname;
++            if( File::Spec->file_name_is_absolute($linkname) ) {
++                $self->_error( qq[Symlink '] . $entry->full_path .
++                    qq[' has absolute target. Not extracting under SECURE EXTRACT MODE] );
++                return;
++            }
++            if( grep { $_ eq '..' } File::Spec->splitdir($linkname) ) {
++                $self->_error( qq[Symlink '] . $entry->full_path .
++                    qq[' target attempts traversal. Not extracting under SECURE EXTRACT MODE] );
++                return;
++            }
++        }
+         my $fail;
+         if( ON_UNIX ) {
+             symlink( $entry->linkname, $file ) or $fail++;
+@@ -967,6 +980,23 @@ sub _make_special_file {
+                 $entry->linkname .q[' failed] if $fail;
+ 
+     } elsif ( $entry->is_hardlink ) {
++        if( !$INSECURE_EXTRACT_MODE ) {
++            my $linkname = $entry->linkname;
++            if( File::Spec->file_name_is_absolute($linkname) ) {
++                $self->_error( qq[Hardlink '] . $entry->full_path .
++                    qq[' has absolute target '$linkname'. Not extracting ] .
++                    qq[under SECURE EXTRACT MODE: extraction itself chmods ] .
++                    qq[the shared inode.] );
++                return;
++            }
++            if( grep { $_ eq '..' } File::Spec->splitdir($linkname) ) {
++                $self->_error( qq[Hardlink '] . $entry->full_path .
++                    qq[' target '$linkname' attempts traversal. Not ] .
++                    qq[extracting under SECURE EXTRACT MODE: extraction ] .
++                    qq[itself chmods the shared inode.] );
++                return;
++            }
++        }
+         my $fail;
+         if( ON_UNIX ) {
+             link( $entry->linkname, $file ) or $fail++;
+diff --git a/cpan/Archive-Tar/t/04_resolved_issues.t b/cpan/Archive-Tar/t/04_resolved_issues.t
+index fc713cd..a0ce3d9 100644
+--- a/cpan/Archive-Tar/t/04_resolved_issues.t
++++ b/cpan/Archive-Tar/t/04_resolved_issues.t
+@@ -219,6 +219,7 @@ SKIP: {
+ 		}
+ 
+     { #use case 1 - in memory extraction
++      local $Archive::Tar::INSECURE_EXTRACT_MODE=1;
+ 			my $t=Archive::Tar->new;
+ 			$t->read( $archname );
+ 			my $r = eval{ $t->extract };
+@@ -230,6 +231,7 @@ SKIP: {
+ 
+ 		{ #use case 2 - iter extraction
+ 		  #$DB::single = 2;
++      local $Archive::Tar::INSECURE_EXTRACT_MODE=1;
+ 			my $next=Archive::Tar->iter( $archname, 1 );
+ 			my $failed = 0;
+ 			#use Data::Dumper;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -58,3 +58,11 @@ fixes/CVE-2025-40909-2.diff
 fixes/CVE-2025-40909-3.diff
 fixes/CVE-2025-40909-metaconfig-reorder.diff
 fixes/CVE-2025-40909-microperl.diff
+0061-Add-verify_SSL-1-to-HTTP-Tiny-to-verify-https-server.patch
+0062-Change-verify_SSL-default-to-1-add-ENV-var-to-enable.patch
+0063-Cpan-entry-size-during-read.patch
+0064-Fix-typo-in-fastForward-72.patch
+0065-remove-use-of-eval-in-globmapper.-73.patch
+0066-perl-perl-security-147-test-cases.patch
+0067-perl-perl-security-147-test-against-the-actual-chara.patch
+0068-Validate-symlink-and-hardlink-linkname-in-SECURE-MOD.patch


### PR DESCRIPTION
* CVE-2023-31484 CPAN.pm does not verify TLS certificates when downloading distributions over HTTPS
* CVE-2023-31486 HTTP::Tiny insecure default TLS configuration
* CVE-2026-9538 Archive::Tar memory exhaustion via attacker controlled entry size field in tar header
* CVE-2026-48959 IO::Uncompress::Unzip CPU exhaustion via per-byte read loop in fastForward
* CVE-2026-48962 IO::Compress arbitrary code execution in File::GlobMapper via an attacker-controlled output glob
* CVE-2026-8376 Perl heap buffer overflow regex in 32-bit builds
* CVE-2026-42496 Archive::Tar extract symlinks with attacker controlled targets outside the extraction directory
* CVE-2026-42497 Archive::Tar extract hardlinks to attacker controlled paths outside the extraction directory
